### PR TITLE
content(about): prevent repeat pinky frags

### DIFF
--- a/domains/jmjanzen.com/templates/bodies/about.ace
+++ b/domains/jmjanzen.com/templates/bodies/about.ace
@@ -28,7 +28,15 @@ div.content
   h2.content-subhead rip & tear & learn
 
   = javascript
+    let clicks = 0
     function boom() {
+      if (++clicks > 1) {
+        if (clicks > 5) {
+          document.getElementById('pinky-caption').innerHTML = 'still a dead pinky'
+        }
+        return
+      }
+
       const path =  `/static/img/pinky-demon-boom.gif#${Math.random()}`
       document.getElementById('pinky').setAttribute('src', path)
       setTimeout(() => {


### PR DESCRIPTION
Looked a bit unintentional. This is more authored. 6 clicks was chosen as the optimally comedic number. May add an even deeper easter egg (like after a delay, or maybe if you click 10 times an arch-vile comes by and revives the pinky (resetting click counter)).

Fun with JavaScript! Is it any wonder this stuff took over the web??